### PR TITLE
chore: update to selfsigned@2 for vuln updates in node-forge dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/watson/https-pem#readme",
   "dependencies": {
-    "selfsigned": "^1.10.1"
+    "selfsigned": "^2.0.1"
   },
   "devDependencies": {
     "standard": "^10.0.2"


### PR DESCRIPTION
There were some vulnerability updates in node-forge@1.3.0.
See https://github.com/jfromaniello/selfsigned/issues/55